### PR TITLE
Feature/01 irb japanese support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2
+FROM ruby:3.4.5
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 WORKDIR /app
 COPY Gemfile /app/Gemfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.4.5
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs locales && locale-gen ja_JP.UTF-8
 WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
 RUN bundle install
-ENV LANG=ja_JP.UTF-8
 ENV TZ=Asia/Tokyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ruby:3.4.5
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs locales && locale-gen ja_JP.UTF-8
+FROM ruby:3.2.2
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - 3000:3000
     volumes:
       - .:/app
+    environment:
+      - LANG=C.UTF-8

--- a/sample.rb
+++ b/sample.rb
@@ -1,0 +1,7 @@
+puts 1 + 2
+
+a = 'Hello, World'
+puts a
+
+b = 'こんにちは'
+puts b


### PR DESCRIPTION
# 概要
irb上というかコンテナ内で日本語入力を受け付けてくれなかった問題を解決
[参考記事：Debian だって日本語入力したい](https://qiita.com/morishio/items/e5c37fa1334a114c7059)

# 原因
DockerfileのENVに設定したja_JP.UTF-8 ロケールがうまく認識されていなかった。
より上位存在であるcompose.ymlでUTF-8設定をさせることで、よりシンプルに文字コードを読み込めるようになった。